### PR TITLE
ERM30868: update bluespice free to 4.2.4 and its docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This <a href="https://github.com/hallowelt/docker-bluespice-free">docker-bluespi
 | `HTTP_PORT`                     | 80               | server http port                                               |
 | `HTTPS_PORT`                    | 443              | server https port                                              |
 | `IMAGE_NAME`                    | bslocal/bsfree   | docker image name to be created                                |
-| `IMAGE_TAG`                     | 4.2.3            | docker image tag                                               |
+| `IMAGE_TAG`                     | 4.2.4            | docker image tag                                               |
 | `DISABLE_PINGBACK`              | no               | sends pingback to the bluespice servers                        |
 | `WIKI_INSTALL_DIR`<sup>1</sup>  | ~/wiki           | dir where bluespice files will be stored                       |
 | `WIKI_BACKUP_LIMIT`<sup>2</sup> | 5                | max limit of backups, after this the  oldest backup is deleted |

--- a/example.env
+++ b/example.env
@@ -6,8 +6,8 @@ BS_PASSWORD=PleaseChangeMe
 BS_DB_PASSWORD=ThisIsDBPassword
 HTTP_PORT=80
 HTTPS_PORT=443
-IMAGE_NAME=bluespice/bluespice-free
-IMAGE_TAG=4.2.3
+IMAGE_NAME=bluespice/free
+IMAGE_TAG=4.2.4
 DISABLE_PINGBACK=no
 
 # if WIKI_INSTALL_DIR path is changed and if this


### PR DESCRIPTION
update bluespice free to 4.2.4 and its docker image

[master]

ERM30868