### PR TITLE
[Bugfix] Nginx rewtire rule is incomplete

### DIFF
--- a/includes/misc/nginx/bluespice.conf
+++ b/includes/misc/nginx/bluespice.conf
@@ -22,8 +22,8 @@ server {
 		expires 7d;
 	}
 	location /wiki/ {
-		rewrite ^/wiki/(?<pagename>.*)$ /w/index.php;
-	}
+                rewrite ^/wiki/(.*)$ /w/index.php?title=$1&$args last;
+        }
 	location = /robots.txt {
 	}
 	location = / {
@@ -65,8 +65,8 @@ server {
 		expires 7d;
 	}
 	location /wiki/ {
-		rewrite ^/wiki/(?<pagename>.*)$ /w/index.php;
-	}
+                rewrite ^/wiki/(.*)$ /w/index.php?title=$1&$args last;
+        }
 	location = /robots.txt {
 	}
 	location = / {


### PR DESCRIPTION
Corrected the /wiki/ rewrite rule as it was missing the page value and the args and it would make certain plugin fail to perform requests.